### PR TITLE
Tradução pagina de regras Gendarme 2.2

### DIFF
--- a/docs/debug+profile/profile/code-coverage.md
+++ b/docs/debug+profile/profile/code-coverage.md
@@ -1,84 +1,84 @@
 ---
-title: Code Coverage
+title: Código de Cobertura
 redirect_from:
   - /Code_Coverage/
 ---
 
-Code Coverage can be used to track how many of the code paths that your program is using are actually exercised.
+A Cobertura de código pode ser usada para controlar a forma como muitos dos caminhos de código que o programa está usando será realmente exercida.
 
-For more information see [Profile](/docs/debug+profile/profile/).
+Para mais informações veja [Perfil](/docs/debug+profile/profile/).
 
 MonoCov
 =======
 
-MonoCov is made up of two components: a code coverage module, and a GUI interface for doing code coverage. This is available as part of the package "monocov" (available [here](http://github.com/mono/monocov)).
+O MonoCov é composto por dois componentes: Um módulo de cobertura de código e uma GUI (interface gráfica) para fazer a cobertura de código. Isto está disponível como parte do pacote "monocov" (diponível [aqui](http://github.com/mono/monocov)).
 
-To use it, run your program like this:
+Para usá-lo, execute o programa dessa forma:
 
 ``` bash
    mono --debug --profile=monocov program.exe
 ```
 
-The coverage information will be output to the program.exe.cov file. Now you can load this file in the GUI with:
+A informação de cobertura será a saída para o arquivo program.exe.cov. Agora você pode carregar esse arquivo na GUI com:
 
 ``` bash
    monocov program.exe.cov
 ```
 
-and browse the namespaces for interesting types you want to check code coverage for. Double clicking on a method will bring up a viewer with the source file of the method with the lines of code not reached by execution highlighted in red.
+e procurar os namespaces de tipos interessantes que você deseja verificar para a cobertura de código. Clicando duas vezes sobre um método trará um visor com o arquivo de origem do método com as linhas de código, não atingidas pela execução destacadas em vermelho.
 
-To limit the collection of data to a specific assembly you can specify it as an argument to the profiler. For example, to consider only the code in mscorlib, use:
+Para limitar a coleta de dados de um conjunto específico, você pode especificá-lo como um argumento para o profiler. Por exemplo, considerar apenas o código em mscorlib, use:
 
 ``` bash
    mono --debug --profile=monocov:+[mscorlib] test-suite.exe
 ```
 
-To be able to easily collect coverage information from the unit tests in the mono mcs directory you can also run the test suite as follows, for example in mcs/class/corlib:
+Para ser capaz de coletar facilmente informações de cobertura dos testes de unidade no diretório msc do mono você também pode executar o teste da seguinte forma, por exemplo mcs/class/corlib:
 
 ``` bash
    make run-test RUNTIME_FLAGS="--profile=monocov:outfile=corlib.cov,+[mscorlib]"
 ```
 
-To use similar options while running unit tests directly with nunit-console2, specify MONO_OPTIONS as follows:
+Para usar opções semelhantes durante a execução de testes de unidade diretamente com nunit-console2, especifique MONO_OPTIONS da seguinte forma:
 
 ``` bash
    MONO_OPTIONS="--profile=monocov:+[MyAssembly]" nunit-console2 MyTestAssembly.dll
 ```
 
-Monocov can also generate a set of HTML pages that display the coverage data. [Here](http://primates.ximian.com/~lupus/corlib-cov/project.html) are the files generated when running the nunit-based test suite for mono's mscorlib with the following command:
+O Monocov também pode gerar um conjunto de páginas HTML que mostram os dados da cobertura. [Aqui](http://primates.ximian.com/~lupus/corlib-cov/project.html) são os arquivos gerados durante a execução do conjunto de testes baseados em nunit para a mscorlib do mono com o seguinte comando:
 
 ``` bash
     monocov --export-html=/tmp/corlib-cov corlib.cov
 ```
 
-Hopefully this tool will help both new and old contributors to easily find untested spots in our libraries and contribute tests for them.
+Esperemos que esta ferramenta irá ajudar os novos colaboradores e os antigos para encontrar facilmente os pontos não testados em nossas bibliotecas e contribuir com testes para eles.
 
-Built-in Code Coverage
+Built-in de Cobertura de CódigoC
 ======================
 
-The built-in code coverage module is fairly limited
+O modulo built-in de cobertura de código é bastante limitada
 
-Mono ships with a code coverage module. This module is activated by using the Mono --profile=cov option. The format is:
+Preparar o Mono com um módulo de cobertura de código. Este módulo é ativado usando a opção Mono --profile = cov. O formato é:
 
     --profile=cov[:assembly-name[/namespace]] test-suite.exe
 
- By default code coverage will default to all the assemblies loaded, you can limit this by specifying the assembly name, for example to perform code coverage in the routines of your program use, for example the following command line limits the code coverage to routines in the "demo" assembly:
+ Por padrão, o código de cobertura será default para todas as assemblies carregados, você pode limitar isso especificando o nome da assembly, por exemplo, para realizar a cobertura de código nas rotinas de uso do seu programa, por exemplo, a seguinte linha de comando limita a cobertura de código para rotinas na assembly "demo"
 
 ``` bash
         mono --profile=cov:demo demo.exe
 ```
 
-Notice that the assembly-name does not include the extension.
+Observe que o nome da assembly não inclui a extensão.
 
-You can further restrict the code coverage output by specifying a namespace:
+Você pode restringir ainda mais a saída de cobertura de código, especificando um namespace:
 
 ``` bash
         mono --profile=cov:demo/My.Utilities demo.exe
 ```
 
-Which will only perform code coverage in the given assembly and namespace.
+Só irá realizar a cobertura de código na assembly em que o namespace for dado.
 
-Typical output looks like this:
+A saída típica se parece com isso:
 
            Not covered: Class:.ctor ()
            Not covered: Class:A ()
@@ -87,4 +87,4 @@ Typical output looks like this:
            Partial coverage: Driver:Main ()
                    offset 0x000a
 
-The offsets displayed are IL offsets.
+Os deslocamentos exibidos são compensações IL.

--- a/docs/debug+profile/profile/code-coverage.md
+++ b/docs/debug+profile/profile/code-coverage.md
@@ -1,12 +1,12 @@
 ---
-title: Código de Cobertura
+title: Cobertura de Código
 redirect_from:
   - /Code_Coverage/
 ---
 
-A Cobertura de código pode ser usada para controlar a forma como muitos dos caminhos de código que o programa está usando será realmente exercutada.
+A Cobertura de código pode ser usada para controlar quantos dos muitos muitos dos caminhos de código que o programa emprega estão sendo realmente exercitados.
 
-Para mais informações veja [Perfil](/docs/debug+profile/profile/).
+Para mais informações veja [Profile](/docs/debug+profile/profile/).
 
 MonoCov
 =======
@@ -33,7 +33,7 @@ Para limitar a coleta de dados de um conjunto específico, você pode especific�
    mono --debug --profile=monocov:+[mscorlib] test-suite.exe
 ```
 
-Para ser capaz de coletar facilmente informações de cobertura dos testes de unidade no diretório msc do mono, você também pode executar o teste da seguinte forma, por exemplo mcs/class/corlib:
+Para ser capaz de coletar facilmente informações de cobertura dos testes de unidade no diretório mcs do mono, você também pode executar o teste da seguinte forma, por exemplo mcs/class/corlib:
 
 ``` bash
    make run-test RUNTIME_FLAGS="--profile=monocov:outfile=corlib.cov,+[mscorlib]"
@@ -51,18 +51,18 @@ O Monocov também pode gerar um conjunto de páginas HTML que mostram os dados d
     monocov --export-html=/tmp/corlib-cov corlib.cov
 ```
 
-Esperemos que esta ferramenta irá ajudar os novos colaboradores e os antigos para encontrar facilmente os pontos não testados em nossas bibliotecas e contribuir com testes para eles.
+Esperamos que esta ferramenta ajude os novos colaboradores e os antigos a encontrar facilmente os pontos não testados em nossas bibliotecas e contribuir com testes para eles.
 
-Built-in de Cobertura de Código
+Cobertura de Código Integrada
 ======================
 
-O modulo built-in de cobertura de código é bastante limitada
+O modulo integrado de cobertura de código é bastante limitado
 
-Preparar o Mono com um módulo de cobertura de código. Este módulo é ativado usando a opção Mono --profile = cov. O formato é:
+O Mono ja vem um módulo integrado de cobertura de código. Este módulo é ativado usando a opção Mono --profile = cov. O formato é:
 
     --profile=cov[:assembly-name[/namespace]] test-suite.exe
 
- Por padrão, o código de cobertura será default para todas as assemblys carregadas, você pode limitar isso especificando o nome da assembly, por exemplo, para realizar a cobertura de código nas rotinas de uso do seu programa, por exemplo, a seguinte linha de comando limita a cobertura de código para rotinas na assembly "demo"
+ Por padrão, o código de cobertura estará operando sobre todas as assemblys carregadas, você pode limitar isso especificando o nome da assembly, por exemplo, para realizar a cobertura de código nas rotinas de uso do seu programa, por exemplo, a seguinte linha de comando limita a cobertura de código para rotinas na assembly "demo"
 
 ``` bash
         mono --profile=cov:demo demo.exe
@@ -76,7 +76,7 @@ Você pode restringir ainda mais a saída de cobertura de código, especificando
         mono --profile=cov:demo/My.Utilities demo.exe
 ```
 
-Só irá realizar a cobertura de código na assembly em que o namespace for dado.
+Nesse caso só sera realizada a cobertura de código nas classes dentro namespace especificado.
 
 A saída típica se parece com isso:
 
@@ -87,4 +87,4 @@ A saída típica se parece com isso:
            Partial coverage: Driver:Main ()
                    offset 0x000a
 
-Os deslocamentos exibidos são compensações IL.
+Os deslocamentos exibidos são deslocamentos IL.

--- a/docs/debug+profile/profile/code-coverage.md
+++ b/docs/debug+profile/profile/code-coverage.md
@@ -4,7 +4,7 @@ redirect_from:
   - /Code_Coverage/
 ---
 
-A Cobertura de código pode ser usada para controlar a forma como muitos dos caminhos de código que o programa está usando será realmente exercida.
+A Cobertura de código pode ser usada para controlar a forma como muitos dos caminhos de código que o programa está usando será realmente exercutada.
 
 Para mais informações veja [Perfil](/docs/debug+profile/profile/).
 
@@ -13,19 +13,19 @@ MonoCov
 
 O MonoCov é composto por dois componentes: Um módulo de cobertura de código e uma GUI (interface gráfica) para fazer a cobertura de código. Isto está disponível como parte do pacote "monocov" (diponível [aqui](http://github.com/mono/monocov)).
 
-Para usá-lo, execute o programa dessa forma:
+Para usá-lo, execute o comando dessa forma:
 
 ``` bash
    mono --debug --profile=monocov program.exe
 ```
 
-A informação de cobertura será a saída para o arquivo program.exe.cov. Agora você pode carregar esse arquivo na GUI com:
+A informação de cobertura será a saída para o arquivo program.exe.cov. Agora você pode carregar esse arquivo na GUI com o comando:
 
 ``` bash
    monocov program.exe.cov
 ```
 
-e procurar os namespaces de tipos interessantes que você deseja verificar para a cobertura de código. Clicando duas vezes sobre um método trará um visor com o arquivo de origem do método com as linhas de código, não atingidas pela execução destacadas em vermelho.
+e procurar os namespaces de tipos que você deseja verificar para a cobertura de código. Clicando duas vezes sobre um método, trará uma tela com o arquivo de origem do método com as linhas de código, as linhas não atingidas pela execução estão destacadas em vermelho.
 
 Para limitar a coleta de dados de um conjunto específico, você pode especificá-lo como um argumento para o profiler. Por exemplo, considerar apenas o código em mscorlib, use:
 
@@ -33,7 +33,7 @@ Para limitar a coleta de dados de um conjunto específico, você pode especific�
    mono --debug --profile=monocov:+[mscorlib] test-suite.exe
 ```
 
-Para ser capaz de coletar facilmente informações de cobertura dos testes de unidade no diretório msc do mono você também pode executar o teste da seguinte forma, por exemplo mcs/class/corlib:
+Para ser capaz de coletar facilmente informações de cobertura dos testes de unidade no diretório msc do mono, você também pode executar o teste da seguinte forma, por exemplo mcs/class/corlib:
 
 ``` bash
    make run-test RUNTIME_FLAGS="--profile=monocov:outfile=corlib.cov,+[mscorlib]"
@@ -53,7 +53,7 @@ O Monocov também pode gerar um conjunto de páginas HTML que mostram os dados d
 
 Esperemos que esta ferramenta irá ajudar os novos colaboradores e os antigos para encontrar facilmente os pontos não testados em nossas bibliotecas e contribuir com testes para eles.
 
-Built-in de Cobertura de CódigoC
+Built-in de Cobertura de Código
 ======================
 
 O modulo built-in de cobertura de código é bastante limitada
@@ -62,7 +62,7 @@ Preparar o Mono com um módulo de cobertura de código. Este módulo é ativado 
 
     --profile=cov[:assembly-name[/namespace]] test-suite.exe
 
- Por padrão, o código de cobertura será default para todas as assemblies carregados, você pode limitar isso especificando o nome da assembly, por exemplo, para realizar a cobertura de código nas rotinas de uso do seu programa, por exemplo, a seguinte linha de comando limita a cobertura de código para rotinas na assembly "demo"
+ Por padrão, o código de cobertura será default para todas as assemblys carregadas, você pode limitar isso especificando o nome da assembly, por exemplo, para realizar a cobertura de código nas rotinas de uso do seu programa, por exemplo, a seguinte linha de comando limita a cobertura de código para rotinas na assembly "demo"
 
 ``` bash
         mono --profile=cov:demo demo.exe

--- a/docs/gui/gtksharp/beginners-guide.md
+++ b/docs/gui/gtksharp/beginners-guide.md
@@ -1,22 +1,22 @@
 ---
-title: Guia para Iniciantes do GTK#
+title: GtkSharpBeginnersGuide
 redirect_from:
   - /GtkSharpBeginnersGuide/
 ---
 
-Prefácio
+Preface
 =======
 
-Este artigo é um guia para iniciantes da prograação Gtk #. Ele irá ajudar aqueles que nunca programaram em uma interface gráfica GTK#, mas antes de começar. Programadores familiarizados com a API do Gtk# de outras línguagens (por exemplo, C, C ++, Perl, Python), também vão achar útil como ele explica o processo básico sobre Mono/C#. O artigo também apresenta o uso de Glade e libglade como um processo para implementar rapidamente interfaces gráficas.
+This article is a beginners guide to Gtk# programming. It will help those who have never programmed a Gtk+ GUI before to get started. Programmers familiar with the Gtk+ API from other languages (e.g. C, C++, perl, python) will also find it useful as it explains the basic process under Mono/C#. The article also introduces the use of Glade and libglade as a process for rapidly implementing graphic user interfaces.
 
-O que é o Gtk#?
+What is Gtk#?
 --------------
 
-[Gtk#](/docs/gui/gtksharp/) É simplesmente colocar um revestimento [gtk+](http://www.gtk.org), em uma estrutura de plataforma (GUI) de interface gráfica.
+[Gtk#](/docs/gui/gtksharp/) put simply is a wrapper on [gtk+](http://www.gtk.org), a cross platform GUI framework.
 
-Adaptado do [gtk+ website](http://www.gtk.org/): *GTK+ é um conjunto de ferramentas multi-plataforma para criar interfaces gráficas de usuário. Oferecendo um conjunto completo de widgets, o GTK+ é adequado para projetos que vão desde pequenas aplicações para brincar atá suites de aplicativos da empresa.*
+Adapted from the [gtk+ website](http://www.gtk.org/): *gtk+ is a multi-platform toolkit for creating graphical user interfaces. Offering a complete set of widgets, gtk+ is suitable for projects ranging from small one-off toys to Enterprise application suites.*
 
-Atualmente GTK+ funciona nativamente em qualquer servidor X, sistema Framebuffer direto e derivitives Microsoft Windows NT. A biblioteca tem origem a partir do Linux, onde ele fornece uma base para o popular ambiente [GNOME] (http://www.gnome.org/) desktop. GTK+ é rotineiramente incluído na maioria das distribuições Linux, e tem se mantido estável em derivitives do Windows NT por um bom tempo agora (provavelmente mais ou menos por volta de 2000, se a memória não me falha).
+Currently gtk+ works natively on any X server, Direct Framebuffer system and Microsoft Windows NT derivitives. The library originates from Linux where it provides a basis for the popular [GNOME](http://www.gnome.org/) desktop environment. gtk+ is routinely included in most Linux distributions, and has been stable on Windows NT derivitives for quite a while now (probably roughly around 2000, if my memory serves me correctly).
 
 Uma portabilidade nativa para Mac OSX está prevista, mas precisa de pessoal disponível para ajudar. Esta é uma chamada para a participar do projeto.
 

--- a/docs/gui/gtksharp/beginners-guide.md
+++ b/docs/gui/gtksharp/beginners-guide.md
@@ -18,9 +18,9 @@ Adapted from the [gtk+ website](http://www.gtk.org/): *gtk+ is a multi-platform 
 
 Currently gtk+ works natively on any X server, Direct Framebuffer system and Microsoft Windows NT derivitives. The library originates from Linux where it provides a basis for the popular [GNOME](http://www.gnome.org/) desktop environment. gtk+ is routinely included in most Linux distributions, and has been stable on Windows NT derivitives for quite a while now (probably roughly around 2000, if my memory serves me correctly).
 
-Uma portabilidade nativa para Mac OSX está prevista, mas precisa de pessoal disponível para ajudar. Esta é uma chamada para a participar do projeto.
+A native port to Mac OSX is planned but needs warm bodies. This is a call for participation.
 
-Um equívoco comum, é que GTK# requer o Mono para funcionar. Isto está muito longe da verdade. GTK# será executado em qualquer tempo de execução compatível com .NET. GTK# é regularmente testado em MS.NET e Mono, mas deve ser executado em qualquer tempo de execução totalmente compatível. Isto significa que se você escrever seus aplicativos em GTK# e deseja rodar em Windows, assim, você pode optar por implantar com apenas GTK# e usar tempo de execução da Microsoft, ou alternativamente implantar com runtime do Mono para Windows.
+One common misconception is that GTK# requires Mono to work. This is far from the truth. GTK# will run on any .NET compatible runtime. GTK# is regularly tested on MS.NET and Mono but should run on any fully compliant runtime. This means if you write your applications in GTK# and wished to run on Windows as well, you can choose to deploy with just GTK# and use Microsoft's runtime, or alternately deploy with Mono's runtime for Windows.
 
 Getting Set Up
 ==============

--- a/docs/gui/gtksharp/beginners-guide.md
+++ b/docs/gui/gtksharp/beginners-guide.md
@@ -1,22 +1,22 @@
 ---
-title: GtkSharpBeginnersGuide
+title: Guia para Iniciantes do GTK#
 redirect_from:
   - /GtkSharpBeginnersGuide/
 ---
 
-Preface
+Prefácio
 =======
 
-This article is a beginners guide to Gtk# programming. It will help those who have never programmed a Gtk+ GUI before to get started. Programmers familiar with the Gtk+ API from other languages (e.g. C, C++, perl, python) will also find it useful as it explains the basic process under Mono/C#. The article also introduces the use of Glade and libglade as a process for rapidly implementing graphic user interfaces.
+Este artigo é um guia para iniciantes da prograação Gtk #. Ele irá ajudar aqueles que nunca programaram em uma interface gráfica GTK#, mas antes de começar. Programadores familiarizados com a API do Gtk# de outras línguagens (por exemplo, C, C ++, Perl, Python), também vão achar útil como ele explica o processo básico sobre Mono/C#. O artigo também apresenta o uso de Glade e libglade como um processo para implementar rapidamente interfaces gráficas.
 
-What is Gtk#?
+O que é o Gtk#?
 --------------
 
-[Gtk#](/docs/gui/gtksharp/) put simply is a wrapper on [gtk+](http://www.gtk.org), a cross platform GUI framework.
+[Gtk#](/docs/gui/gtksharp/) É simplesmente colocar um revestimento [gtk+](http://www.gtk.org), em uma estrutura de plataforma (GUI) de interface gráfica.
 
-Adapted from the [gtk+ website](http://www.gtk.org/): *gtk+ is a multi-platform toolkit for creating graphical user interfaces. Offering a complete set of widgets, gtk+ is suitable for projects ranging from small one-off toys to Enterprise application suites.*
+Adaptado do [gtk+ website](http://www.gtk.org/): *GTK+ é um conjunto de ferramentas multi-plataforma para criar interfaces gráficas de usuário. Oferecendo um conjunto completo de widgets, o GTK+ é adequado para projetos que vão desde pequenas aplicações para brincar atá suites de aplicativos da empresa.*
 
-Currently gtk+ works natively on any X server, Direct Framebuffer system and Microsoft Windows NT derivitives. The library originates from Linux where it provides a basis for the popular [GNOME](http://www.gnome.org/) desktop environment. gtk+ is routinely included in most Linux distributions, and has been stable on Windows NT derivitives for quite a while now (probably roughly around 2000, if my memory serves me correctly).
+Atualmente GTK+ funciona nativamente em qualquer servidor X, sistema Framebuffer direto e derivitives Microsoft Windows NT. A biblioteca tem origem a partir do Linux, onde ele fornece uma base para o popular ambiente [GNOME] (http://www.gnome.org/) desktop. GTK+ é rotineiramente incluído na maioria das distribuições Linux, e tem se mantido estável em derivitives do Windows NT por um bom tempo agora (provavelmente mais ou menos por volta de 2000, se a memória não me falha).
 
 A native port to Mac OSX is planned but needs warm bodies. This is a call for participation.
 

--- a/docs/gui/gtksharp/beginners-guide.md
+++ b/docs/gui/gtksharp/beginners-guide.md
@@ -18,9 +18,9 @@ Adaptado do [gtk+ website](http://www.gtk.org/): *GTK+ é um conjunto de ferrame
 
 Atualmente GTK+ funciona nativamente em qualquer servidor X, sistema Framebuffer direto e derivitives Microsoft Windows NT. A biblioteca tem origem a partir do Linux, onde ele fornece uma base para o popular ambiente [GNOME] (http://www.gnome.org/) desktop. GTK+ é rotineiramente incluído na maioria das distribuições Linux, e tem se mantido estável em derivitives do Windows NT por um bom tempo agora (provavelmente mais ou menos por volta de 2000, se a memória não me falha).
 
-A native port to Mac OSX is planned but needs warm bodies. This is a call for participation.
+Uma portabilidade nativa para Mac OSX está prevista, mas precisa de pessoal disponível para ajudar. Esta é uma chamada para a participar do projeto.
 
-One common misconception is that GTK# requires Mono to work. This is far from the truth. GTK# will run on any .NET compatible runtime. GTK# is regularly tested on MS.NET and Mono but should run on any fully compliant runtime. This means if you write your applications in GTK# and wished to run on Windows as well, you can choose to deploy with just GTK# and use Microsoft's runtime, or alternately deploy with Mono's runtime for Windows.
+Um equívoco comum, é que GTK# requer o Mono para funcionar. Isto está muito longe da verdade. GTK# será executado em qualquer tempo de execução compatível com .NET. GTK# é regularmente testado em MS.NET e Mono, mas deve ser executado em qualquer tempo de execução totalmente compatível. Isto significa que se você escrever seus aplicativos em GTK# e deseja rodar em Windows, assim, você pode optar por implantar com apenas GTK# e usar tempo de execução da Microsoft, ou alternativamente implantar com runtime do Mono para Windows.
 
 Getting Set Up
 ==============

--- a/docs/tools+libraries/tools/gendarme/rules/security-cas.md
+++ b/docs/tools+libraries/tools/gendarme/rules/security-cas.md
@@ -1,18 +1,18 @@
 ---
-title: "Gendarme Rules: Security - CAS"
+title: "Regras Gendarme: Segurança - CAS"
 redirect_from:
   - /Gendarme.Rules.Security.Cas/
 ---
 
-[Gendarme](/docs/tools+libraries/tools/gendarme/)'s Code Access Security (CAS) rules are located in the **Gendarme.Rules.Security.Cas.dll** assembly. Latest sources are available from [git](https://github.com/mono/mono-tools/tree/master/gendarme/rules/Gendarme.Rules.Security.Cas).
+[Gendarme](/docs/tools+libraries/tools/gendarme/)'s Code Access Security (CAS) As regras estão localizados na  assembly **Gendarme.Rules.Security.Cas.dll**. Os Últimos sources(código fonte) estão disponíveis a partir do [git](https://github.com/mono/mono-tools/tree/master/gendarme/rules/Gendarme.Rules.Security.Cas).
 
 <table>
 <col width="100%" />
 <tbody>
 <tr class="odd">
-<td align="left"><h2>Table of contents</h2>
+<td align="left"><h2>Tabela de conteúdo</h2>
 <ul>
-<li><a href="#rules">1 Rules</a>
+<li><a href="#rules">1 Regras</a>
 <ul>
 <li><a href="#addmissingtypeinheritancedemandrule">1.1 AddMissingTypeInheritanceDemandRule</a></li>
 <li><a href="#donotexposefieldsinsecuredtyperule">1.2 DoNotExposeFieldsInSecuredTypeRule</a></li>
@@ -22,86 +22,86 @@ redirect_from:
 <li><a href="#reviewsuppressunmanagedcodesecurityusagerule">1.6 ReviewSuppressUnmanagedCodeSecurityUsageRule</a></li>
 <li><a href="#securegetobjectdataoverridesrule">1.7 SecureGetObjectDataOverridesRule</a></li>
 </ul></li>
-<li><a href="#feedback">2 Feedback</a></li>
+<li><a href="#feedback">2 Comentários</a></li>
 </ul></td>
 </tr>
 </tbody>
 </table>
 
-Rules
+Regras
 =====
 
 ### AddMissingTypeInheritanceDemandRule
 
-The rule checks for types that are not **sealed** but have a **LinkDemand**. In this case the type should also have an **InheritanceDemand** for the same permissions. An alternative is to seal the type.
+Essa regra verifica se há tipos que não são **selados** mas tem um **LinkDemand**. Neste caso, o tipo também deve ter um **InheritanceDemand** para as mesmas permissões. Uma alternativa é o de selar o tipo.
 
-**Bad** example:
+Exemplo **Errado**:
 
 ``` csharp
 [SecurityPermission (SecurityAction.LinkDemand, ControlThread = true)]
-public class Bad {
+public class Errado{
 }
 ```
 
-**Good** example (InheritanceDemand):
+Exemplo **Correto** usando (InheritanceDemand):
 
 ``` csharp
 [SecurityPermission (SecurityAction.LinkDemand, ControlThread = true)]
 [SecurityPermission (SecurityAction.InheritanceDemand, ControlThread = true)]
-public class Correct {
+public class Correto {
 }
 ```
 
-**Good** example (sealed):
+Exemplo **Correto** usando (sealed):
 
 ``` csharp
 [SecurityPermission (SecurityAction.LinkDemand, ControlThread = true)]
-public sealed class Correct {
+public sealed class Correto {
 }
 ```
 
-**Notes**
+**Notas**
 
--   Before Gendarme 2.2 this rule was part of Gendarme.Rules.Security and named TypeLinkDemandRule.
+-   Antes do Gendarme 2.2 essa regra era parte de Gendarme.Rules.Security a da nomenclatura TypeLinkDemandRule.
 
 ### DoNotExposeFieldsInSecuredTypeRule
 
-The rule checks for types that are secured by **Demand** or **LinkDemand**but also expose visible fields. Access to these fields is not covered by the declarative demands, opening potential security holes.
+Essa regra verifica os tipos que são protegidos por **Demand** ou **LinkDemand** mas também expõe campos visíveis. O acesso a estes campos não são cobertos pelas exigências declarativas, abrindo brechas de segurança em potencial.
 
-**Bad** example:
+Exemplo **Errado**:
 
 ``` csharp
 [SecurityPermission (SecurityAction.LinkDemand, ControlThread = true)]
-public class Bad {
+public class Errado {
 }
 ```
 
-**Good** example (InheritanceDemand):
+Exemplo **Correto** usando (InheritanceDemand):
 
 ``` csharp
 [SecurityPermission (SecurityAction.LinkDemand, ControlThread = true)]
 [SecurityPermission (SecurityAction.InheritanceDemand, ControlThread = true)]
-public class Correct {
+public class Correto {
 }
 ```
 
-**Good** example (sealed):
+Exemplo **Correto** usando (sealed):
 
 ``` csharp
 [SecurityPermission (SecurityAction.LinkDemand, ControlThread = true)]
-public sealed class Correct {
+public sealed class Correto {
 }
 ```
 
-**Notes**
+**Notas**
 
--   Before Gendarme 2.2 this rule was part of Gendarme.Rules.Security and named TypeExposeFieldsRule.
+-   Antes do Gendarme 2.2 essa regra era parte da Gendarme.Rules.Security e da nomenclatura TypeExposeFieldsRule.
 
 ### DoNotExposeMethodsProtectedByLinkDemandRule
 
-This rule checks for visible methods that are less protected (i.e. lower security requirements) than the method they call. If the called methods are protected by a **LinkDemand** then the caller can be used to bypass security checks.
+Esta regra verifica métodos visíveis que são menos protegidos (ou seja, os requisitos de segurança são mais baixas) do que o método que eles chamam. Se os métodos  chamados são protegidos por um **LinkDemand** em seguida, o chamador pode ser utilizado para verificações de segurança de bypass.
 
-**Bad** example:
+Exemplo **Errado**:
 
 ``` csharp
 public class BaseClass {
@@ -112,7 +112,7 @@ public class BaseClass {
 }
  
 public class Class : BaseClass  {
-    // bad since a caller with only ControlAppDomain will be able to call the base method
+    // Errado, já que um chamador com apenas ControlAppDomain será capaz de chamar o método base
     [SecurityPermission (SecurityAction.LinkDemand, ControlAppDomain = true)]
     public override void VirtualMethod ()
     {
@@ -121,7 +121,7 @@ public class Class : BaseClass  {
 }
 ```
 
-**Good** example (InheritanceDemand):
+Exemplo **Correto** usando (InheritanceDemand):
 
 ``` csharp
 public class BaseClass {
@@ -132,7 +132,7 @@ public class BaseClass {
 }
  
 public class Class : BaseClass  {
-    // ok since this permission cover the base class permission
+    // Correto desde essa permissão cubra a permissão da classe base
     [SecurityPermission (SecurityAction.LinkDemand, Unrestricted = true)]
     public override void VirtualMethod ()
     {
@@ -141,15 +141,15 @@ public class Class : BaseClass  {
 }
 ```
 
-**Notes**
+**Notas**
 
--   Before Gendarme 2.2 this rule was part of Gendarme.Rules.Security and named MethodCallWithSubsetLinkDemandRule.
+-   Antes do Gendarme 2.2 essa regra era parte do Gendarme.Rules.Security e da nomenclatura MethodCallWithSubsetLinkDemandRule.
 
 ### DoNotReduceTypeSecurityOnMethodsRule
 
-This rule checks for types that have declarative security permission which aren't a subset of the security permission of some of their methods.
+Esta regra verifica os tipos que têm permissão de segurança declarativa, que não são um subconjunto da permissão de alguns de seus métodos de segurança.
 
-**Bad** example:
+Exemplo **Errado**
 
 ``` csharp
 [SecurityPermission (SecurityAction.Assert, ControlThread = true)]
@@ -161,7 +161,7 @@ public class NotSubset {
 }
 ```
 
-**Good** example:
+Exemplo **Correto**
 
 ``` csharp
 [SecurityPermission (SecurityAction.Assert, ControlThread = true)]
@@ -173,78 +173,78 @@ public class Subset {
 }
 ```
 
-**Notes**
+**Notas**
 
--   Before Gendarme 2.2 this rule was part of Gendarme.Rules.Security and named TypeIsNotSubsetOfMethodSecurityRule.
+-   Antes do Gendarme 2.2 essa regra era parte do Gendarme.Rules.Security a da nomenclatura TypeIsNotSubsetOfMethodSecurityRule.
 
 ### ReviewSealedTypeWithInheritanceDemandRule
 
-This rule checks for sealed types that have **InheritanceDemand** declarative security applied to them. Since those types cannot be inherited from the **InheritanceDemand** will never be executed by the runtime. Check if the permission is required and, if so, change the **SecurityAction** to the correct one. Otherwise remove the permission.
+Esta regra verifica os tipos fechados que têm **InheritanceDemand** segurança declarativa aplicada a eles. Desde que esses tipos não possam ser herdadas do **InheritanceDemand** nunca serão executado pelo tempo de execução. Verifique se a permissão é necessária e, em caso afirmativo, altere o **SecurityAction** para a correta. Caso contrário, remover a permissão.
 
-**Bad** example:
-
-``` csharp
-[SecurityPermission (SecurityAction.InheritanceDemand, Unrestricted = true)]
-public sealed class Bad {
-}
-```
-
-**Good** example (non sealed):
+Exemplo **Errado**:
 
 ``` csharp
 [SecurityPermission (SecurityAction.InheritanceDemand, Unrestricted = true)]
-public class Good {
+public sealed class Errado {
 }
 ```
 
-**Good** example (LinkDemand):
+Exemplo **Correto** usando (sem sealed):
+
+``` csharp
+[SecurityPermission (SecurityAction.InheritanceDemand, Unrestricted = true)]
+public class Correto {
+}
+```
+
+Exemplo **Correto** usando (LinkDemand):
 
 ``` csharp
 [SecurityPermission (SecurityAction.LinkDemand, Unrestricted = true)]
-public sealed class Good {
+public sealed class Correto {
 }
 ```
 
-**Notes**
+**Notas**
 
--   Before Gendarme 2.2 this rule was part of Gendarme.Rules.Security and named SealedTypeWithInheritanceDemandRule.
+-   Antes do Gendarme 2.2 essa regra era parte do Gendarme.Rules.Security e da nomenclatura SealedTypeWithInheritanceDemandRule.
 
 ### ReviewSuppressUnmanagedCodeSecurityUsageRule
 
-This rule fires if a type or method is decorated with the **[SuppressUnmanagedCodeSecurity]**attribute. This attribute reduces the security checks done when executing unmanaged code and its usage should be reviewed to confirm that no exploitable security holes are present.
+Essa regra dispara, se um tipo ou método é marcado com o atributo **[SuppressUnmanagedCodeSecurity]**. Esse atributo reduz as verificações de segurança feitas durante a execução de código não gerenciado, e seu uso deve ser revisto para confirmar que não há falhas de segurança exploráveis presentes na implementação.
 
-Example:
+Exemplo:
 
 ``` csharp
 [SuppressUnmanagedCodeSecurity]
-public class Safe {
+public class Seguro {
     [DllImport ("User32.dll")]
     static extern Boolean MessageBeep (UInt32 beepType);
 }
 ```
 
-**Notes**
+**Notas**
 
--   This is an Audit rule. As such it does not check for valid or invalid patterns but warns about a specific problem that needs to be reviewed by someone.
+-   Essa é uma regra de auditoria. Como tal, ela não verifica padrões válidos ou inválidos, mas adverte sobre um problema específico que precisa ser revisado por alguém.
 
 ### SecureGetObjectDataOverridesRule
 
-This rule fires if a type implements **System.Runtime.Serialization.ISerializable**but the **GetObjectData** method is not protected with a **Demand** or **LinkDemand** for **SerializationFormatter**.
+Esta regra é acionado quando se implementa um tipo **System.Runtime.Serialization.ISerializable** mas o método **GetObjectData** não está protegido com uma **Demand** ou um **LinkDemand** para **SerializationFormatter**.
 
-**Bad** example:
+Exemplo **Errado**:
 
 ``` csharp
-public class Bad : ISerializable {
+public class Errodo : ISerializable {
     public override void GetObjectData (SerializationInfo info, StreamingContext context)
     {
     }
 }
 ```
 
-**Good** example:
+Exemplo **Correto**:
 
 ``` csharp
-public class Good : ISerializable {
+public class Correto : ISerializable {
     [SecurityPermission (SecurityAction.LinkDemand, SerializationFormatter = true)]
     public override void GetObjectData (SerializationInfo info, StreamingContext context)
     {
@@ -252,12 +252,12 @@ public class Good : ISerializable {
 }
 ```
 
-**Notes**
+**Notas**
 
--   Before Gendarme 2.2 this rule was part of Gendarme.Rules.Security.
+-   Antes do Gendarme 2.2 essa regra era parte do Gendarme.Rules.Security.
 
-Feedback
+Comentarios
 ========
 
-Please report any documentation errors, typos or suggestions to the [Gendarme Google Group](http://groups.google.com/group/gendarme). Thanks!
+Por favor, reporte qualquer erro na documentação, erros de digitação ou sugestões para o [Gendarme Google Group](http://groups.google.com/group/gendarme). Obrigado!
 

--- a/docs/tools+libraries/tools/gendarme/rules/security-cas.md
+++ b/docs/tools+libraries/tools/gendarme/rules/security-cas.md
@@ -4,13 +4,13 @@ redirect_from:
   - /Gendarme.Rules.Security.Cas/
 ---
 
-[Gendarme](/docs/tools+libraries/tools/gendarme/)'s Code Access Security (CAS) As regras estão localizados na  assembly **Gendarme.Rules.Security.Cas.dll**. Os Últimos sources(código fonte) estão disponíveis a partir do [git](https://github.com/mono/mono-tools/tree/master/gendarme/rules/Gendarme.Rules.Security.Cas).
+As regras do [Gendarme](/docs/tools+libraries/tools/gendarme/) para o Code Access Security (CAS) estão localizados na  assembly **Gendarme.Rules.Security.Cas.dll**. Os Últimos fontes correntes estão disponíveis a partir do [git](https://github.com/mono/mono-tools/tree/master/gendarme/rules/Gendarme.Rules.Security.Cas).
 
 <table>
 <col width="100%" />
 <tbody>
 <tr class="odd">
-<td align="left"><h2>Tabela de conteúdo</h2>
+<td align="left"><h2>Sumário</h2>
 <ul>
 <li><a href="#rules">1 Regras</a>
 <ul>
@@ -62,7 +62,7 @@ public sealed class Correto {
 
 **Notas**
 
--   Antes do Gendarme 2.2 essa regra era parte de Gendarme.Rules.Security a da nomenclatura TypeLinkDemandRule.
+-   Antes do Gendarme 2.2 essa regra era parte de Gendarme.Rules.Security com o nome de TypeLinkDemandRule.
 
 ### DoNotExposeFieldsInSecuredTypeRule
 
@@ -143,7 +143,7 @@ public class Class : BaseClass  {
 
 **Notas**
 
--   Antes do Gendarme 2.2 essa regra era parte do Gendarme.Rules.Security e da nomenclatura MethodCallWithSubsetLinkDemandRule.
+-   Antes do Gendarme 2.2 essa regra era parte do Gendarme.Rules.Security com o nome de MethodCallWithSubsetLinkDemandRule.
 
 ### DoNotReduceTypeSecurityOnMethodsRule
 
@@ -207,7 +207,7 @@ public sealed class Correto {
 
 **Notas**
 
--   Antes do Gendarme 2.2 essa regra era parte do Gendarme.Rules.Security e da nomenclatura SealedTypeWithInheritanceDemandRule.
+-   Antes do Gendarme 2.2 essa regra era parte do Gendarme.Rules.Security com o nome de SealedTypeWithInheritanceDemandRule.
 
 ### ReviewSuppressUnmanagedCodeSecurityUsageRule
 


### PR DESCRIPTION
tradução da pagina de regras referente as regras de Segurança CAS
utilizando o Gendarme 2.2
