### PR TITLE
Tradução do arquivo trampolines.md

### DIFF
--- a/docs/advanced/runtime/docs/trampolines.md
+++ b/docs/advanced/runtime/docs/trampolines.md
@@ -4,7 +4,7 @@ redirect_from:
   - /Mono:Runtime:Documentation:Trampolines/
 ---
 
-Trampolines are small, hand-written pieces of assembly code used to perform various tasks in the mono runtime. They are generated at runtime using the native code generation macros used by the JIT. They usually have a corresponding C function they can fall back to if they need to perform a more complicated task. They can be viewed as ways to pass control from JITted code back to the runtime.
+Trampolins são pequenos, pedaços de código assembly escritos à mão usados para executar várias tarefas em tempo de execução do mono. Eles são gerados em tempo de execução usando as macros de geração de código nativas utilizadas pelo JIT. Eles geralmente têm uma função C correspondente que pode ser utilizada caso seja necessário executar uma tarefa mais complexa. Eles podem ser vistos como formas de passar o controle do código JIT de volta para o tempo de execução.
 
 The common code for all architectures is in mini-trampolines.c, this file contains the trampoline creation functions plus the C functions called by the trampolines. The tramp-\<ARCH\>.c files contain the arch-dependent code which creates the trampolines themselves.
 

--- a/docs/advanced/runtime/docs/trampolines.md
+++ b/docs/advanced/runtime/docs/trampolines.md
@@ -34,23 +34,23 @@ A função deve retornar um ponteiro para o trampolim recém-criado, alocando me
 -   Salvar a informação do trampolim em uma imagem AOT em modo 'full-aot'.
 -   Salvar a informação de debug sobre o trampolim em modo XDEBUG.
 
-### JIT Trampolines
+### Trampolins JIT
 
-These trampolines are used to JIT compile a method the first time it is called. When the JIT compiles a call instruction, it doesn't compile the called method right away. Instead, it creates a JIT trampoline, and emits a call instruction referencing the trampoline. When the trampoline is called, it calls mono_magic_trampoline () which compiles the target method, and returns the address of the compiled code to the trampoline which branches to it. This process is somewhat slow, so mono_magic_trampoline () tries to patch the calling JITted code so it calls the compiled code instead of the trampoline from now on. This is done by mono_arch_patch_callsite () in tramp-\<ARCH\>.c.
+Estes trampolins são utilizados para compilar um método JIT a primeira vez que ele é chamado. Quando o JIT compila uma instrução de chamada, ele não compila o método chamado de imediato. Como alternativa, ele cria um trampolim JIT, e emite uma chamada de instrução referenciando o trampolim. Quando o trampolim é chamado, ele chama mono_magic_trampoline () que compila o método de destino, e retorna um endereço do código compilado para o trampolim que se ramifica a ele. Este processo é um pouco lento, então mono_magic_trampoline () tenta consertar o código gerado pelo JIT assim ele chama o código compilado em vez do trampolim a partir de agora. Isso é feito pelo mono_arch_patch_callsite () em tramp-\<ARCH\>.c.
 
-### Virtual Call Trampolines
+### Chamadas Virtuais de Trampolins
 
-There is one virtual call trampoline per vtable slot index. The trampoline uses this index plus the 'this' argument which is passed in a fixed register/stack slots by the managed calling convention to obtain the virtual method which needs to be compiled. It then patches the vtable slot with the address of the newly compiled method.
+Há uma chamada virtual de trampolim por índice vtable. O trampolim usa este índice mais o argumento 'this' que é passado num registro fixo/pilha pela convenção de chamada gerenciada para obter o método virtual que é necessário para compilar. Em seguida, ele corrige o conector vtable com o endereço do novo método compilado.
 
 \<TODO IMT\>
 
-### Jump Trampolines
+### Salto de Trampolins
 
-Jump trampolines are very similar to JIT trampolines, they even use the same mono_magic_trampoline () C function. They are used to implement the LDFTN and the JMP IL opcodes.
+Salto de trampolins são muito similares aos trampolins JIT, eles ainda usam a mesma função C mono_magic_trampoline (). Eles são usados para implementar os códigos de operação LDFTN e o JMP IL.
 
-### Class Init Trampolines
+### Classe Init Trampolines
 
-These trampolines are used to implement the type initialization sematics of the CLI spec. They call the mono_class_init_trampoline () C function which executes the class initializer of the class passed as the trampoline argument, then replaces the code calling the class init trampoline with NOPs so it is not executed anymore.
+Estes trampolins são usados para implementar os tipos de inicialização sematics da especificação CLI. Eles chamam a função C mono_class_init_trampoline () que executa o inicializador da classe passada como argumento do trampolim, em seguida, substitui o código chamadando a classe init trampoline com NOPs para que ele não seja mais executado.
 
 ### Generic Class Init Trampoline
 

--- a/docs/advanced/runtime/docs/trampolines.md
+++ b/docs/advanced/runtime/docs/trampolines.md
@@ -6,33 +6,33 @@ redirect_from:
 
 Trampolins são pequenos, pedaços de código assembly escritos à mão usados para executar várias tarefas em tempo de execução do mono. Eles são gerados em tempo de execução usando as macros de geração de código nativas utilizadas pelo JIT. Eles geralmente têm uma função C correspondente que pode ser utilizada caso seja necessário executar uma tarefa mais complexa. Eles podem ser vistos como formas de passar o controle do código JIT de volta para o tempo de execução.
 
-The common code for all architectures is in mini-trampolines.c, this file contains the trampoline creation functions plus the C functions called by the trampolines. The tramp-\<ARCH\>.c files contain the arch-dependent code which creates the trampolines themselves.
+O código comum para todas as arquiteturas está em mini-trampolines.c, este arquivo contém funções de criação de trampolim mais as funções C chamadas pelos trampolins. Os arquivos tramp-\<ARCH\>.c contém o código dependente da arquitetura que cria os próprios trampolins.
 
-Most, but not all trampolines consist of two parts:
+A maioria, mas não todos os trampolins consistem de duas partes:
 
--   a generic part containing most of the code. This is created by the mono_arch_create_trampoline_code () function in tramp-\<ARCH\>.c. Generic trampolines can be large (1kb).
--   a specific part whose job is to call the generic part, passing in a parameter. The parameter to pass and the method by it is passed depends on the type of the trampoline. Specific trampolines are created by the mono_arch_create_specific_trampoline () function in tramp-\<ARCH\>.c. Specific trampolines are small, since the runtime creates lots of them.
+-   uma parte genérica contendo a maior parte do código. Esta é criada pela função mono_arch_create_trampoline_code () em tramp-\<ARCH\>.c. Trampolins genéricos podem ser grandes (1kb).
+-   uma parte específica cuja a função é chamar a parte genérica, passando um parâmetro. O parâmetro para passar e o método pelo qual é passado depende do tipo de trampolim. Trampolins específicos são criados pela função mono_arch_create_specific_trampoline () em tramp-\<ARCH\>.c. Trampolins específicos são pequenos, desde que sejam criados vários em tempo de execução.
 
-The generic part saves the machine state to the stack, and calls one of the trampoline functions in mini-trampolines.c with the state, the call site, and the argument passed by the specific trampoline. After the C function returns, it either returns normally, or branches to the address returned by the C function, depending on the trampoline type.
+A parte genérica salva o estado da máquina para a pilha, e chama uma das funções trampolim em mini-trampolines.c com o estado, o site de chamada, e o argumento passado para um trampolim específico. Após a função C retornar, normalmente retorna, ou ramos para o endereço retornado pela função C, dependendo do tipo de trampolim.
 
-Trampoline types are given by the MonoTrampolineType enumeration in [mini.h](https://github.com/mono/mono/blob/master/mono/mini/mini.h).
+Tipos de trampolim são dadas pela enumeração MonoTrampolineType em [mini.h](https://github.com/mono/mono/blob/master/mono/mini/mini.h).
 
-The platform specific code for trampolines is in the file tramp-\<ARCH\>.c for each architecture, while the cross platform code is in mini-trampolines.c. There are two types of functions in mini-trampolines.c:
+O código específico da plataforma para trampolins está no arquivo tramp-\<ARCH\>.c para cada arquitetura, enquanto o código entre plataformas está em mini-trampolines.c. Há dois tipos de funções em mini-trampolines.c:
 
--   The actual C functions called by the trampolines.
--   Functions to create the different trampolines types.
+-   As funções C reais chamados pelos trampolins.
+-   Funções para criar os diferentes tipos de trampolins.
 
-Trampoline creation functions have the following signature:
+Funções de criação de trampolim tem a seguinte assinatura:
 
 ``` bash
 gpointer
 mono_arch_create_foo_trampoline (<args>, MonoTrampInfo **info, gboolean aot)
 ```
 
-The function should return a pointer to the newly created trampoline, allocating memory from either the global code manager, or from a domain's code manager. If INFO is not NULL, it is set to a pointer to a MonoTrampInfo structure, which contains information about the trampoline, like its name, unwind info, etc. This is used for two purposes:
+A função deve retornar um ponteiro para o trampolim recém-criado, alocando memória a partir de qualquer gerenciador de código global, ou a partir de um gerenciador de código de domínio. Se INFO não for NULL, ele é definido como um ponteiro para uma estrutura do tipo MonoTrampInfo, que contém informação sobre o trampolim, como o seu nome, informação genérica, etc. Isto é utilizado para duas finalidades:
 
--   Saving the trampoline info an AOT image in 'full-aot' mode.
--   Saving debug info about the trampoline in XDEBUG mode.
+-   Salvar a informação do trampolim em uma imagem AOT em modo 'full-aot'.
+-   Salvar a informação de debug sobre o trampolim em modo XDEBUG.
 
 ### JIT Trampolines
 

--- a/docs/advanced/runtime/docs/trampolines.md
+++ b/docs/advanced/runtime/docs/trampolines.md
@@ -52,29 +52,29 @@ Salto de trampolins são muito similares aos trampolins JIT, eles ainda usam a m
 
 Estes trampolins são usados para implementar os tipos de inicialização sematics da especificação CLI. Eles chamam a função C mono_class_init_trampoline () que executa o inicializador da classe passada como argumento do trampolim, em seguida, substitui o código chamadando a classe init trampoline com NOPs para que ele não seja mais executado.
 
-### Generic Class Init Trampoline
+### Classe Genérica Init Trampoline
 
-This is similar to the class init trampolines, but is used for initalizing classes which are only known at run-time, in generic-shared code. It receives the class to be initialized in a register instead of from a specific trampoline. This means there is only one instance of this trampoline.
+É semelhante a classe init trampolines, mas é utilizada para inicializar classes que são conhecidas somente em tempo de execução, em código compartilhado genérico. Ele recebe a classe para ser inicializada em um registro em vez de um trampolim específico. Isto significa que existe apenas uma instância deste trampolim.
 
-### RGCTX Lazy Fetch Trampolines
+### Trampolins RGCTX Lazy Fetch
 
-These are used for fetching values from a runtime generic context, lazily initializing the values if they do not exist yet. There is one instance of this trampoline for each offset value.
+Estes são usados para buscar valores de um contexto genérico em tempo de execução, inicializando lentamente os valores se eles ainda não existem. Há uma instância desse trampolim para cada valor de deslocamento.
 
-### AOT Trampolines
+### Trampolins AOT
 
-These are similar to the JIT trampolines but instead of receiving a MonoMethod to compile, they receive an image+token pair. If the method identified by this pair is also AOT compiled, the address of its compiled code can be obtained without loading the metadata for the method.
+Estes são semelhantes aos trampolins JIT mas em vez de receber um MonoMethod para compilar, eles recebem um par imagem+token. Se o método identificado por este par é também compilado de forma AOT (Ahead Of Time - Antes do Tempo), o endereço do seu código compilado pode ser obtido sem carregar o metadado para o método.
 
-### AOT PLT Trampolines
+### Trampolins AOT PLT
 
-These trampolines handle calls made from AOT code though the PLT.
+Estes trampolins manipulam tanto chamadas de código AOT quanto PLT.
 
-### Delegate Trampolines
+### Trampolins Delegate
 
-These trampolines are used to handle the first call made to the delegate though its Invoke method. They call mono_delegate_trampoline () which creates a specialized calling sequence optimized to the delegate instance before calling it. Further calls will go through to this optimized code sequence.
+Estes trampolins são usados para manipular a primeira chamada para o delegate que seu método Invoke. Eles chamam mono_delegate_trampoline () que cria uma sequência de chamadas específicas otimizadas para a instância delegada antes de chamá-la. Chamadas adicionais passam por essa sequência de código otimizado.
 
-### Monitor Enter/Exit Trampolines
+### Trampolins Monitor Enter/Exit
 
-These trampolines implement the fastpath of Monitor.Enter/Exit on some platforms.
+Estes trampolins implementam o fastpath de Monitor.Enter/Exit em algumas plataformas.
 
 \<TODO REMAINING TRAMPOLINE TYPES\>
 


### PR DESCRIPTION
Tradução do arquivo de inglês para português (Brasil).

Caminho: docs/advanced/runtime/docs/trampolines.md
